### PR TITLE
add pytest and ipdb dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+pytest = "*"
+ipdb = "*"
 
 [dev-packages]
 


### PR DESCRIPTION
These packages were missing and I had to add to run the tests (at least pytest for sure, just added ipdb for good measure?)